### PR TITLE
Introduce compatability for Ubuntu

### DIFF
--- a/Snake/snake.py
+++ b/Snake/snake.py
@@ -11,7 +11,7 @@ class SnakeGame:
     snake_heads = ["[A]", "[>]", "[V]", "[<]"]
     apple_field = "[O]"
     MOVE_CURSOR_UP = "\033[A"
-    key_map = "WDSA"
+    key_map = "wdsa"
     score = 0
 
     def __init__(self, field_size=(10, 10), update_delay=0.5) -> None:


### PR DESCRIPTION
On ubuntu, the keyboard package complains that "W" (which is w + shift) is not mapped to any key. This fixes this issue.